### PR TITLE
fix(auth): propagate credential loading exceptions and handle startup…

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,8 @@ async def lifespan(app: FastAPI):
         # In a production environment, you might want to exit here
         print(f"CRITICAL: Failed to load credentials: {e}")
     yield
+
+
 app = FastAPI(lifespan=lifespan)
 
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,17 @@ async def load_credentials():
     """
     Load credentials from CSV file into hashmap at application startup.
     """
-    load_credentials_from_csv()
+    try:
+        load_credentials_from_csv()
+    except Exception as e:
+        log_json(logger, 'critical', {
+            "event": "startup_failure",
+            "reason": "credentials_load_failed",
+            "error": str(e)
+        })
+        # If credentials can't be loaded, the app might be in an inconsistent state
+        # In a production environment, you might want to exit here
+        print(f"CRITICAL: Failed to load credentials: {e}")
 
 
 def validate_credentials(username: str, password: str) -> bool:


### PR DESCRIPTION
## Description
This PR addresses an issue where credential loading failures were silently caught and masked, leading to inconsistent application states where callers couldn't distinguish between a successful empty load and a failure.

### Changes
- **[csv_loader.py](cci:7://file:///c:/Users/samue/Documents/GitHub/login-app/csv_loader.py:0:0-0:0)**: 
  - Removed `try-except` blocks to allow exceptions (`FileNotFoundError`, `ValueError`, etc.) to propagate.
  - Added `credentials_map.clear()` at the start of the loading process to prevent stale or merged data if the function is called multiple times.
  - Added a check for the existence of a comma in each CSV line to catch malformed data early.
- **[main.py](cci:7://file:///c:/Users/samue/Documents/GitHub/login-app/main.py:0:0-0:0)**:
  - Updated the `@app.on_event("startup")` handler to catch exceptions from the credential loader.
  - Added critical level logging and a console print statement when loading fails at startup.

## Verification Results
- **Negative Test**: Renamed the [unpw](cci:7://file:///c:/Users/samue/Documents/GitHub/login-app/unpw:0:0-0:0) file. Verified that the application logs a `critical` event and prints a failure message to the console.
- **Positive Test**: Restored the [unpw](cci:7://file:///c:/Users/samue/Documents/GitHub/login-app/unpw:0:0-0:0) file. Verified that credentials are loaded correctly into the hashmap.
- **Malformed Data Test**: Added a line without a comma to [unpw](cci:7://file:///c:/Users/samue/Documents/GitHub/login-app/unpw:0:0-0:0). Verified that a `ValueError` is raised with a descriptive message.

## Dependencies
No new dependencies added.

Fixes #11